### PR TITLE
feat: implement which-account command

### DIFF
--- a/commands/no-save.go
+++ b/commands/no-save.go
@@ -9,57 +9,22 @@
 package commands
 
 import (
-	"database/sql"
-	"log"
-
 	utils "github.com/pagefaultgames/ticketune/utils"
 
 	"github.com/amatsagu/tempest"
 )
 
 var noSaveCommandDescription = "Ping the user associated with this ticket and ask them to try to use a different browser"
+var tryDifferentBrowserMessage = "If there is another device or browser you've played on before, please use the gear there.\n" +
+	"Otherwise, please provide your username, as well as the date of account creation or the date you last played on this account " +
+	"(last played meaning the date you last started any kind of run)."
 
 var NoSaveCommmand = tempest.Command{
 	Name:                "no-save",
 	Description:         noSaveCommandDescription,
 	RequiredPermissions: tempest.ADMINISTRATOR_PERMISSION_FLAG,
-	SlashCommandHandler: noSaveCommmandImpl,
-	Contexts:            []tempest.InteractionContextType{tempest.GUILD_CONTEXT_TYPE},
-}
-
-var tryDifferentBrowserMessage = "If there is another device or browser you've played on before, please use the gear there.\n" +
-	"Otherwise, please provide your username, as well as the date of account creation or the date you last played on this account " +
-	"(last played meaning the date you last started any kind of run)."
-
-func noSaveCommmandImpl(itx *tempest.CommandInteraction) {
-	// Get the user associated with this thread (this handles responding to the interaction on error)
-	userID, err := utils.GetUserFromThread(itx)
-	if err != sql.ErrNoRows && err != nil {
-		return
-	}
-
-	// The message to send publicly to the thread
-	msg := "Hi <@" + userID.String() + ">!\n" + tryDifferentBrowserMessage
-
-	// The message to use to respond to the interaction
-	responseMsg := "The user has been requested to try a different device/browser."
-
-	if err != nil {
-		log.Println("Error fetching user for thread:", err)
-		msg = tryWithDiscordMessage
-		responseMsg = "I couldn't find a user associated with this thread in my database, so I can't ping them." +
-			"However, I've sent the message to the thread."
-	}
-
-	// Send the user a message
-	_, err = itx.Client.SendLinearMessage(
-		itx.ChannelID,
-		msg,
-	)
-	if err != nil {
-		itx.SendLinearReply("Something went wrong trying to send the message: "+err.Error(), true)
-		return
-	}
-
-	itx.SendLinearReply(responseMsg, true)
+	SlashCommandHandler: func(itx *tempest.CommandInteraction) {
+		utils.SayCommandTemplate(itx, tryDifferentBrowserMessage, "The user has been requested to try a different device/browser.")
+	},
+	Contexts: []tempest.InteractionContextType{tempest.GUILD_CONTEXT_TYPE},
 }

--- a/commands/old-account.go
+++ b/commands/old-account.go
@@ -9,8 +9,6 @@
 package commands
 
 import (
-	"database/sql"
-	"log"
 	"strconv"
 
 	"github.com/pagefaultgames/ticketune/utils"
@@ -133,32 +131,5 @@ func oldAccountCommandImpl(itx *tempest.CommandInteraction, isDefault bool) {
 		msg = defaultMessageWithUsername(username)
 	}
 
-	// Get the user associated with this thread (this handles responding to the	 interaction on error)
-	userID, err := utils.GetUserFromThread(itx)
-	if err != sql.ErrNoRows && err != nil {
-		return
-	}
-
-	// The message to use to respond to the interaction
-	responseMsg := "The user has been notified."
-
-	msg = "Hi <@" + userID.String() + ">!\n" + msg
-
-	if err != nil {
-		log.Println("Error fetching user for thread:", err)
-		responseMsg = "I couldn't find a user associated with this thread in my database, so I can't ping them." +
-			"However, I've sent the message to the thread."
-	}
-
-	// Send the user a message
-	_, err = itx.Client.SendLinearMessage(
-		itx.ChannelID,
-		msg,
-	)
-	if err != nil {
-		itx.SendLinearReply("Something went wrong trying to send the message: "+err.Error(), true)
-		return
-	}
-
-	itx.SendLinearReply(responseMsg, true)
+	utils.SayCommandTemplate(itx, msg, "The user has been notified.")
 }

--- a/commands/try-discord.go
+++ b/commands/try-discord.go
@@ -9,9 +9,6 @@
 package commands
 
 import (
-	"database/sql"
-	"log"
-
 	utils "github.com/pagefaultgames/ticketune/utils"
 
 	"github.com/amatsagu/tempest"
@@ -19,56 +16,18 @@ import (
 
 var tryDiscordCommandDescription = "Ping the user associated with this ticket and ask them to log into discord"
 
-var TryDiscordCommand = tempest.Command{
-	Name:                "try-discord",
-	Description:         tryDiscordCommandDescription,
-	RequiredPermissions: tempest.ADMINISTRATOR_PERMISSION_FLAG,
-	SlashCommandHandler: tryDiscordCommandImpl,
-	Contexts:            []tempest.InteractionContextType{tempest.GUILD_CONTEXT_TYPE},
-}
-
 var tryWithDiscordMessage = "Please try to log in with Discord now, and let us know here if it works!\n\n" +
 	"Alternatively, you can also try this:\n" +
 	"Open Discord on your web browser. Connect to your Discord account (this one you are using). " +
 	"Open PokéRogue in another tab, while keeping the Discord one open. " +
 	"On the login page, click on the Discord button to try to log in with Discord."
 
-func tryDiscordCommandImpl(itx *tempest.CommandInteraction) {
-
-	// Get the user associated with this thread (this handles responding to the interaction on error)
-	userID, err := utils.GetUserFromThread(itx)
-	if err != sql.ErrNoRows && err != nil {
-		return
-	}
-
-	threadID := itx.ChannelID
-
-	// The message to send publicaly to the thread
-	var msg string
-	// The message to use to respond to the interaction
-	var responseMsg string
-
-	if err == nil {
-		msg = "Hi <@" + userID.String() + ">!\n" + tryWithDiscordMessage
-		responseMsg = "The user has been requested to attempt a login."
-	} else {
-		log.Println("Error fetching user for thread:", err)
-		msg = tryWithDiscordMessage
-		responseMsg = "I couldn't find a user associated with this thread in my database, so I can't ping them." +
-			"However, I've sent the login message to the thread."
-	}
-
-	// Send the user a message
-	_, err = itx.Client.SendLinearMessage(
-		threadID,
-		msg,
-	)
-
-	if err != nil {
-		itx.SendLinearReply("Something went wrong trying to send the message: "+err.Error(), true)
-		return
-	}
-
-	itx.SendLinearReply(responseMsg, true)
-
+var TryDiscordCommand = tempest.Command{
+	Name:                "try-discord",
+	Description:         tryDiscordCommandDescription,
+	RequiredPermissions: tempest.ADMINISTRATOR_PERMISSION_FLAG,
+	SlashCommandHandler: func(itx *tempest.CommandInteraction) {
+		utils.SayCommandTemplate(itx, tryWithDiscordMessage, "The user has been requested to attempt a login.")
+	},
+	Contexts: []tempest.InteractionContextType{tempest.GUILD_CONTEXT_TYPE},
 }

--- a/commands/which-account.go
+++ b/commands/which-account.go
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Pagefault Games
+ * SPDX-FileContributor: SirzBenjie
+ * SPDX-FileContributor: patapancakes
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package commands
+
+import (
+	utils "github.com/pagefaultgames/ticketune/utils"
+
+	"github.com/amatsagu/tempest"
+)
+
+var whichAccountCommandDescription = "Ping the user associated with this ticket and ask them which account they would like help with"
+
+const whichAccountMessage = "Which account would you like help with?"
+
+var WhichAccountCommand = tempest.Command{
+	Name:                "which-account",
+	Description:         whichAccountCommandDescription,
+	RequiredPermissions: tempest.ADMINISTRATOR_PERMISSION_FLAG,
+	SlashCommandHandler: func(itx *tempest.CommandInteraction) {
+		utils.SayCommandTemplate(itx, whichAccountMessage, "The user has been asked which account.")
+	},
+	Contexts: []tempest.InteractionContextType{tempest.GUILD_CONTEXT_TYPE},
+}

--- a/utils/commands.go
+++ b/utils/commands.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"database/sql"
+	"log"
+
+	"github.com/amatsagu/tempest"
+)
+
+// Base say command functionality reusable by multiple command implementations
+// Parameters:
+// `itx“: The command interaction to respond to
+// `content“: The message content to send to the thread
+// `invokerResponse`: The message to send back to the command invoker on success. On error, a relevant error message will be sent instead.
+func SayCommandTemplate(itx *tempest.CommandInteraction,
+	content string,
+	invokerResponse string,
+) {
+	// Get the user associated with this thread (this handles responding to the interaction on error)
+	userID, err := GetUserFromThread(itx)
+	if err != sql.ErrNoRows && err != nil {
+		return
+	}
+
+	// The message to send publicly to the thread
+	msg := "Hi <@" + userID.String() + ">!\n" + content
+
+	if err != nil {
+		log.Println("Error fetching user for thread:", err)
+		msg = content
+		invokerResponse = "I couldn't find a user associated with this thread in my database, so I can't ping them." +
+			"However, I've sent the message to the thread."
+	}
+
+	// Send the user a message
+	_, err = itx.Client.SendLinearMessage(
+		itx.ChannelID,
+		msg,
+	)
+	if err != nil {
+		itx.SendLinearReply("Something went wrong trying to send the message: "+err.Error(), true)
+		return
+	}
+
+	itx.SendLinearReply(invokerResponse, true)
+}


### PR DESCRIPTION
Adds a `which-account` command.
Creates a new utility method for commands that are just wrappers around sending a static message, to be used for code deduplication.